### PR TITLE
CSS Grab shadow

### DIFF
--- a/core/lively/morphic/GrabShadows.js
+++ b/core/lively/morphic/GrabShadows.js
@@ -1,26 +1,25 @@
-module('lively.morphic.GrabShadows').requires('lively.morphic.Events', 'lively.morphic.StyleSheets').toRun(function () {
+module('lively.morphic.GrabShadows').requires('lively.morphic.Events', 'lively.morphic.StyleSheetsHTML').toRun(function () {
 
     Trait('GrabShadowsTrait', 'grabbing', {
         addMorphWithShadow: lively.morphic.HandMorph.prototype.addMorphWithShadow
             .wrap(function (proceed, morph) {
                 this.addMorph(morph);
-                morph.addStyleClassName('has-grab-shadow-from-handmorph');
             }),
-        dropContentsOn: lively.morphic.HandMorph.prototype.dropContentsOn
-            .wrap(function (proceed, morph, evt) {
-                this.submorphs.each(function(m){
-                        m.removeStyleClassName('has-grab-shadow-from-handmorph');
-                    });
-                return proceed(morph, evt);
-            }),
-        getStyleSheet: lively.morphic.HandMorph.prototype.getStyleSheet
+        compileStyleSheet: lively.morphic.HandMorph.prototype.compileStyleSheet
             .wrap(function(proceed) {
-                return (proceed() || '') + ' '
-                    + '.has-grab-shadow-from-handmorph '
-                    +'{box-shadow: 8px 8px 4px rgba(0,0,0,0.5)}';
+                var cssRules = this.getStyleSheetRules(),
+                       grabShadowRule = new lively.morphic.StyleSheetRule(
+                        '.HandMorph > .Morph',
+                        [new lively.morphic.StyleSheetDeclaration(
+                                'box-shadow', ['8px', '8px', '4px', 'rgba(0,0,0,0.5)'],
+                                null, true
+                            )]
+                    );
+                cssRules.push(grabShadowRule);
+                return proceed(cssRules);
             })
     }).applyTo(lively.morphic.HandMorph, {
-        override: ['addMorphWithShadow', 'dropContentsOn', 'getStyleSheet']
+        override: ['addMorphWithShadow', 'compileStyleSheet']
     })
 
 });


### PR DESCRIPTION
Here is an example how to create a grab shadow without copying the whole morph (of course we won't need a separate trait for that if we establish this in the master).

Only works for HTML rendering right now tho.
