### PR TITLE
Added conditional waiting support for asyncronous tests

### DIFF
--- a/core/lively/TestFramework.js
+++ b/core/lively/TestFramework.js
@@ -480,6 +480,22 @@ TestCase.subclass('AsyncTestCase',
             try { func.call(self) } catch(e) { self.done(); self.addAndSignalFailure(e) }
         }).delay(ms / 1000)
     },
+    waitFor: function(guardFunc, interval, callback) {
+        var self = this;
+        console.log('Scheduled wait for ' + self.currentSelector);
+        (function() {
+            try {
+                if (guardFunc.call(self)) {
+                    callback();
+                } else {
+                    self.waitFor(guardFunc, interval, callback);
+                }
+            } catch(e) {
+                self.done();
+                self.addAndSignalFailure(e);
+            }
+        }).delay(interval / 1000)
+    },
     runTest: function(aSelector) {
         if (!this.shouldRun) return;
         this.currentSelector = aSelector || this.currentSelector;

--- a/core/lively/tests/TestFrameworkTests.js
+++ b/core/lively/tests/TestFrameworkTests.js
@@ -643,8 +643,22 @@ AsyncTestCase.subclass('lively.tests.TestFrameworkTests.AsyncTestCaseTest', {
         this.assert(Global.test2AsyncCalled, 'test2AsyncCalled was not called');
         this.assertEquals(2, Global.tearDownCalled, 'tearDown not twice called');
         this.done();
+    },
+    test4WaitFor: function() {
+        // This test is an example of an aync test using wait
+        // which checks the correct order of execution
+        var steps = ['a'];
+        var checkpoint = false;
+        this.waitFor(
+            function() { steps.push('c'); return checkpoint; }, 20,
+            function() { steps.push('e'); });
+        this.delay(function() { steps.push('b'); }, 10);
+        this.delay(function() { steps.push('d'); checkpoint = true; }, 30);
+        this.delay(function() {
+            this.assertEqualState(['a', 'b', 'c', 'd', 'c', 'e'], steps);
+            this.done();
+        }, 50);
     }
-
 });
 
 }) // end of module


### PR DESCRIPTION
Example usage:

``` javascript
AsyncTestCase.subclass('DragonTest', {
    testSlaysDragon: function() {
        var dragonAlive = true;
        var siegfried = function() { dragonAlive = false; };
        this.delay(siegfried, Math.random() * 42);
        this.waitFor(
            function() { return !dragonAlive; }, // guard funtion
            10,                                  // interval
            function() { this.done(); });        // callback
    }
});
```
