### PR TITLE
WIP: Fixing text padding

### DIFF
--- a/core/lively/morphic/HTML.js
+++ b/core/lively/morphic/HTML.js
@@ -580,8 +580,7 @@ lively.morphic.Text.addMethods(
     createTextNodeHTML: function() {
         var node = XHTMLNS.create('div');
         node.className = 'visibleSelection';
-        node.style.cssText = 'position: absolute;' // needed for text extent calculation
-                           + 'word-wrap: break-word;';
+        node.style.cssText = 'word-wrap: break-word;';
         return node;
     }
 });


### PR DESCRIPTION
The width of the text node does not compensate correctly for padding.
#### Example Code

``` javascript
var str = 'hmmmmmmmmmmm';
var txt = new lively.morphic.Text(lively.rect(20,10,60,50), str);
txt.openInWorld();
txt.focus();
txt.setPadding(lively.Rectangle.inset(5, 10));
```
#### Result

![paddingbug](https://f.cloud.github.com/assets/479238/187103/cf7b467c-7d45-11e2-82b1-6f90d8715b0e.png)
