### PR TITLE
Line height support for Text

### DIFF
--- a/core/lively/morphic/HTML.js
+++ b/core/lively/morphic/HTML.js
@@ -406,6 +406,7 @@ lively.morphic.Text.addMethods(
         setPadding: 'setPaddingHTML',
         setAlign: 'setAlignHTML',
         setVerticalAlign: 'setVerticalAlignHTML',
+        setLineHeight: 'setLineHeightHTML',
         setDisplay: 'setDisplayHTML',
         setWhiteSpaceHandling: 'setWhiteSpaceHandlingHTML',
         setWordBreak: 'setWordBreakHTML',
@@ -421,6 +422,7 @@ lively.morphic.Text.addMethods(
         this.setFontWeightHTML(ctx, this.getFontWeight());
         this.setAlignHTML(ctx, this.getAlign());
         this.setVerticalAlignHTML(ctx, this.getVerticalAlign());
+        this.setLineHeightHTML(ctx, this.getLineHeight());
         this.setDisplayHTML(ctx, this.getDisplay());
         this.setTextColorHTML(ctx, this.getTextColor());
         this.setWhiteSpaceHandlingHTML(ctx, this.getWhiteSpaceHandling());
@@ -529,6 +531,10 @@ lively.morphic.Text.addMethods(
     setVerticalAlignHTML: function(ctx, valignMode) {
         if (ctx.textNode)
             ctx.textNode.style.verticalAlign = valignMode;
+    },
+    setLineHeightHTML: function(ctx, lineHeight) {
+        if (ctx.textNode)
+            ctx.textNode.style.lineHeight = lineHeight;
     },
     setDisplayHTML: function(ctx, mode) {
         if (ctx.textNode)

--- a/core/lively/morphic/StyleSheetsHTML.js
+++ b/core/lively/morphic/StyleSheetsHTML.js
@@ -45,6 +45,7 @@ lively.morphic.Text.addMethods('Stylesheets', {
         this.setTextColorHTML(ctx, this.getTextColor());
 
         this.setVerticalAlignHTML(ctx, this.getVerticalAlign());
+        this.setLineHeightHTML(ctx, this.getLineHeight());
         this.setTextDecorationHTML(ctx, this.getTextDecoration());
         this.setWordBreakHTML(ctx, this.getWordBreak());
         this.setDisplayHTML(ctx, this.getDisplay());
@@ -162,6 +163,13 @@ Trait('StyleSheetsHTMLTextTrait',
             proceed(ctx, value || null);
         }
     }),
+    setLineHeightHTML: lively.morphic.Text.prototype.setLineHeightHTML.wrap(function (proceed, ctx, value) {
+        if (this.morphicGetter('TextStylingMode')) {
+            proceed(ctx, 'inherit');
+        } else {
+            proceed(ctx, value || null);
+        }
+    }),
     setDisplayHTML: lively.morphic.Text.prototype.setDisplayHTML.wrap(function (proceed, ctx, value) {
         if (this.morphicGetter('TextStylingMode')) {
             proceed(ctx, 'inherit');
@@ -179,8 +187,8 @@ Trait('StyleSheetsHTMLTextTrait',
 }).applyTo(lively.morphic.Text, {
     override: ['setAlignHTML',  'setFontFamilyHTML',
         'setFontSizeHTML', 'setFontStyleHTML', 'setFontWeightHTML', 'setTextColorHTML',
-        'setTextDecorationHTML', 'setVerticalAlignHTML', 'setDisplayHTML', 'setWordBreakHTML'
-        ]
+        'setTextDecorationHTML', 'setVerticalAlignHTML', 'setDisplayHTML', 'setWordBreakHTML',
+        'setLineHeightHTML']
 });
 
 Trait('StyleSheetsHTMLTrait',

--- a/core/lively/morphic/TextCore.js
+++ b/core/lively/morphic/TextCore.js
@@ -302,6 +302,7 @@ lively.morphic.Morph.subclass('lively.morphic.Text', Trait('ScrollableTrait'), T
         if (spec.padding !== undefined) this.setPadding(spec.padding);
         if (spec.align !== undefined) this.setAlign(spec.align);
         if (spec.verticalAlign !== undefined) this.setVerticalAlign(spec.verticalAlign);
+        if (spec.lineHeight !== undefined) this.setLineHeight(spec.lineHeight);
         if (spec.display !== undefined) this.setDisplay(spec.display);
         if (spec.whiteSpaceHandling !== undefined) this.setWhiteSpaceHandling(spec.whiteSpaceHandling);
         if (spec.syntaxHighlighting !== undefined) spec.syntaxHighlighting ? this.enableSyntaxHighlighting() : this.disableSyntaxHighlighting();
@@ -389,6 +390,8 @@ lively.morphic.Morph.subclass('lively.morphic.Text', Trait('ScrollableTrait'), T
     getAlign: function() { return this.morphicGetter('Align') },
     setVerticalAlign: function(valign) { return this.morphicSetter('VerticalAlign', valign) },
     getVerticalAlign: function() { return this.morphicGetter('VerticalAlign') },
+    setLineHeight: function(lheight) { return this.morphicSetter('LineHeight', lheight) },
+    getLineHeight: function() { return this.morphicGetter('LineHeight') },
     setDisplay: function(mode) { return this.morphicSetter('Display', mode) },
     getDisplay: function() { return this.morphicGetter('Display') },
 


### PR DESCRIPTION
The `line-height` property exists in CSS and can be very useful for texts in Lively.

This example below creates three texts. The first one uses the default line height, the second one is a lighter, less dense text with 150% line height and the third sets the line height to the height of the whole text morph which has the effect of vertically centering a line of text:

``` javascript
var bounds = lively.pt(200, 200).extentAsRectangle();
var str = "Lorem Ipsum dolor sit amet. ".times(20);

var txt1 = new lively.morphic.Text(bounds, str);
txt1.openInWorld();

var txt2 = new lively.morphic.Text(bounds, str);
txt2.setPosition(lively.pt(200, 0));
txt2.setLineHeight(1.5);
txt2.openInWorld();

var txt3 = new lively.morphic.Text(bounds, "centered");
txt3.setPosition(lively.pt(400, 0));
txt3.setLineHeight("200px");
txt3.setAlign("center");
txt3.openInWorld();
```

![line-height](https://f.cloud.github.com/assets/479238/345825/9007ded0-9e2c-11e2-9a4d-f162842779a8.png)
