### PR TITLE
Use special cursor to indicate potential drag and drop targets

### DIFF
--- a/core/lively/morphic/Events.js
+++ b/core/lively/morphic/Events.js
@@ -2059,19 +2059,40 @@ lively.morphic.Morph.subclass('lively.morphic.HandMorph',
 
         pos = pos.scaleBy(1/this.world().getScale());
         this.setPosition(pos);
-        if (!this.carriesGrabbedMorphs) return;
-        var carriedMorph = this.submorphs.detect(function(ea) {return !ea.isGrabShadow;}),
+
+        // show layout placeholder and drop cursor when carrying a morph
+        // and hovering over a potential target morph
+        var carriedMorph, topmostMorph, layouter;
+        if (this.carriesGrabbedMorphs) {
+            carriedMorph = this.submorphs.detect(function(ea) {return !ea.isGrabShadow;}),
             topmostMorph = this.world().getTopmostMorph(evt.getPosition()),
             layouter = topmostMorph.getLayouter();
+        }
         if (!carriedMorph
           || !topmostMorph
+          || topmostMorph.isWorld
           || !topmostMorph.isLayoutable
           || !topmostMorph.wantsDroppedMorph(carriedMorph)
-          || !carriedMorph.wantsToBeDroppedInto(topmostMorph)) { return; }
+          || !carriedMorph.wantsToBeDroppedInto(topmostMorph)) {
+            // hide drop cursor if there is one
+            if (this.dropCursor) {
+                worldNode.style.cursor = 'default';
+                delete this.dropCursor;
+            }
+            // destroy placeholder if there is one
+            if (carriedMorph && carriedMorph.placeholder) {
+                carriedMorph.destroyPlaceholder();
+            }
+            return;
+        }
+        // show drop cursor unless there is already one
+        if (!this.dropCursor) {
+            worldNode.style.cursor = 'alias';
+            this.dropCursor = true;
+        }
+        // show placeholder if there is a layout
         if (layouter && layouter.displaysPlaceholders()) {
             layouter.showPlaceholderFor(carriedMorph, evt);
-        } else if (carriedMorph.placeholder) {
-            carriedMorph.destroyPlaceholder();
         }
     }
 });

--- a/core/lively/morphic/Serialization.js
+++ b/core/lively/morphic/Serialization.js
@@ -397,7 +397,7 @@ lively.morphic.Script.addMethods(
 
 lively.morphic.HandMorph.addMethods(
 'serialization', {
-    doNotSerialize: ['internalClickedOnMorph']
+    doNotSerialize: ['internalClickedOnMorph', 'dropCursor']
 });
 
 }) // end of module


### PR DESCRIPTION
When carrying a morph and hovering over a potential drop target, like another morph with a layout, a placeholder will be shown. However, if there is no layout then it is sometimes difficult to see whether the morph would be dropped into the target or just into the world.

The screenshots below show this behavior:

![normal-cursor](https://f.cloud.github.com/assets/479238/354587/659b082c-a0a5-11e2-8c70-c7e1483a51cb.png) ![drop-cursor](https://f.cloud.github.com/assets/479238/354588/6b8277ac-a0a5-11e2-9af7-e32d591e82d8.png)

I decided to use the "alias" cursor as it seems to be supported by many browsers and easily understood. There is also the option to use a custom image as cursor.

More about cursor options in CSS: https://developer.mozilla.org/en-US/docs/CSS/cursor
