### PR TITLE
Mixin Traits

### DIFF
--- a/core/lively/Traits.js
+++ b/core/lively/Traits.js
@@ -50,7 +50,6 @@ Object.subclass('RealTrait',
         return this;
     },
     mixin: function() {
-        this.isMixin = true;
         this.applyToClass = function(applyToClass, klass, options) {
             if (!klass.mixinClass) {
                 var cls = klass.superclass.subclass();

--- a/core/lively/tests/TraitTests.js
+++ b/core/lively/tests/TraitTests.js
@@ -220,7 +220,6 @@ lively.tests.TraitsTests.BaseTest.subclass('lively.tests.TraitsTests.TraitCreati
         Trait('Foo', {c: function() { return 4 }});
         this.assertEquals(5, obj.c());
     }
-
 });
 
 lively.tests.TraitsTests.BaseTest.subclass('lively.tests.TraitsTests.ObjectTraits',


### PR DESCRIPTION
In contrast to traits, mixins become part of the class hierachy. This makes it possible to use `super` to call the parent definition of the method - regardless whether it is defined in a class or a mixin.

This implementation sets the `__proto__` property of an object after its creation which is non-standard and may not be supported in future versions of Firefox and Chrome (see [this comment](http://stackoverflow.com/a/7156682)).

The example below uses `super` to call the `serialize` method of the trait, while being derived from the `Game` class. This is done by defining a normal trait and invoking `mixin()` to make it part of the inheritence chain.

``` javascript
Trait('Serializable', {
    serialize: function() {
        return JSON.stringify(this.toJSON());
    },
    toJSON: function() {
        return {class: this.constructor.type};
    }
});

Object.subclass('Game', {
    initialize: function() {
        this.score = 23;
    }
});

Game.subclass('SerializableGame', Trait('Serializable').mixin(), {
    toJSON: function($super) {
        var result = $super();
        result.score = this.score;
        return result;
    }
});

var game = new SerializableGame();
game.serialize(); // {"class":"SerializableGame","score":23}
```
