### PR TITLE
Respect word-wrapping when fitting text morph extent

### DIFF
--- a/core/lively/morphic/TextCore.js
+++ b/core/lively/morphic/TextCore.js
@@ -441,13 +441,9 @@ lively.morphic.Morph.subclass('lively.morphic.Text', Trait('ScrollableTrait'), T
 
         var isClip = this.isClip(),
             fixedWidth = isClip || this.fixedWidth,
-            fixedHeight = isClip || this.fixedWidth,
-            whiteSpaceHandling = this.getWhiteSpaceHandling();
+            fixedHeight = isClip || this.fixedWidth;
 
         if (this.fixedWidth && this.fixedHeight) return;
-
-        // we need "pre" for finding out how long a line really is...
-        if (whiteSpaceHandling !== 'pre') this.setWhiteSpaceHandling('pre');
 
         var owners = this.ownerChain();
         for (var i = 0; i < owners.length; i++) {
@@ -470,8 +466,6 @@ lively.morphic.Morph.subclass('lively.morphic.Text', Trait('ScrollableTrait'), T
         if (width !== extent.x || height !== extent.y) {
             this.setExtent(pt(width, height));
         }
-
-        this.setWhiteSpaceHandling(whiteSpaceHandling);
     },
 
     setTextNodeToFitMorphExtent: function() {


### PR DESCRIPTION
The `fit` method of TextMorph always sets the whitespace handling to 'pre' which means that texts with normal word-break will not get the correct extent.

The following pictures shows a text morph with a background color. The extent of the text morph if off because the line wrapping was ignored:

![line-wrapping-bug](https://f.cloud.github.com/assets/479238/498644/2e81262e-bc1a-11e2-943e-2b4ddaef199f.png)
