### PR TITLE
File Parsing: allow more white space in module definitions

### DIFF
--- a/core/lively/ide/FileParsing.js
+++ b/core/lively/ide/FileParsing.js
@@ -726,8 +726,8 @@ CodeParser.subclass('JsParser', {
     },
 
     parseModuleBegin: function() {
-        var moduleBeginRegex = /^\s*module\([\'\"](.*)[\'\"]\)\.requires\(.*toRun\(.*$/,
-            match = this.currentLine.match(moduleBeginRegex);
+        var moduleBeginRegex = /^\s*module\([\'\"](.*)[\'\"]\)\s*\.\s*requires\(\s*.*\s*\.\s*toRun\(\s*.*/,
+            match = this.src.slice(this.ptr).match(moduleBeginRegex);
         if (!match) return null;
         if (this.debugMode) {
             console.log('Found module start in line ' +  this.currentLineNo());

--- a/core/lively/ide/tests/FileParserTests.js
+++ b/core/lively/ide/tests/FileParserTests.js
@@ -562,6 +562,21 @@ main.logCompletion("main").delay(Config.mainDelay);\n\
         this.assertEquals(result[0].stopIndex, src.length-1);
     },
 
+    testParseModuleDefWithLineBreaks: function() {
+        var src = "module('lively.BetterScripting').\n" +
+                  "requires('lively.TileScripting')\n" +
+                  ".toRun(\n" +
+                  "function(lively.ide.tests.FileParserTests) {\n\nMorph.addMethods({})\n});";
+
+        var result = this.sut.parseSource(src);
+
+        this.assertEquals(result.length, 1);
+        this.assertEquals(result[0].type, 'moduleDef');
+        this.assertEquals(result[0].name, 'lively.BetterScripting');
+        this.assertEquals(result[0].startIndex, 0);
+        this.assertEquals(result[0].stopIndex, src.length-1);
+    },
+
       testParseModuleAndClass: function() {
         var src = 'module(\'lively.xyz\').requires(\'abc.js\').toRun(function(lively.ide.tests.FileParserTests) {\n\Object.subclass(\'Abcdef\', {\n}); // this is a comment\n});';
         var result = this.sut.parseSource(src);


### PR DESCRIPTION
previously, the file parser looked for the beginning of a module definition, meaning the first line of the following example, only on a single line and didn't allow any white space in it.

``` javascript
module(...).requires(...).toRun(function(){
...
})
```

i stumbled over this after adding line breaks between the three calls at the beginning of my modules, when i had particularly long module names...resulting in SCBs that only show content in the first pane (files) and none in the other panes (classes, protocols, and methods).

these changes let the file parser check the whole remaining source for the beginning of a module definition, meaning also multiple lines, and allowing white space in such module beginnings. so, the following example would still be parsed as a module definition:

``` javascript
module(...).
requires(...).
toRun(function(){
...
})
```

after this commit, the file parser tests doesn't seem to run any longer. also, opening and saving files in the system browser doesn't seem (much) slower.
