### PR TITLE
Trigger autocompletion when typing (without having to press ctrl+space)

### DIFF
--- a/core/lib/ace/lively-ace.js
+++ b/core/lib/ace/lively-ace.js
@@ -18126,7 +18126,8 @@ var lang = require("./lib/lang");
 var snippetManager = require("./snippets").snippetManager;
 
 var Autocomplete = function() {
-    this.autoInsert = true;
+    // Only do auto insertion if the autocompletion isn't triggered automatically.
+    this.autoInsert = !Config.get('aceDefaultAutoTriggerAutocompletion');
     this.keyboardHandler = new HashHandler();
     this.keyboardHandler.bindKeys(this.commands);
 

--- a/core/lively/defaultconfig.js
+++ b/core/lively/defaultconfig.js
@@ -484,6 +484,7 @@ Config.addOptions(
     ['aceDefaultUseJavaScriptLinter', true, "Linting JavaScript code on-the-fly"],
     ['aceDefaultShowActiveLine', false, "Current line is highlighted"],
     ['aceDefaultEnableAutocompletion', true, "Should autocompletion be enabled?"],
+    ['aceDefaultAutoTriggerAutocompletion', false, "Should autocompletion be triggered when typing?"],
     ['aceDefaultShowWarnings', true, "Should autocompletion be enabled?"],
     ['aceDefaultShowErrors', true, "Show syntax errors in programming language mode?"],
     ['computeCodeEditorCompletionsOnStartup', true, 'when enabled all JS files udner core/ are read on startup nd their content is used to compute word completions'],

--- a/core/lively/ide/CodeEditor.js
+++ b/core/lively/ide/CodeEditor.js
@@ -193,6 +193,8 @@ lively.morphic.Morph.subclass('lively.morphic.CodeEditor',
         this.setShowWarnings(this.getShowWarnings());
         this.setInputAllowed(this.inputAllowed());
 
+        this.activateAutocompletionWhenTyping();
+
         // 4) run after setup callbacks
         var cbs = this.aceEditorAfterSetupCallbacks;
         if (!cbs) return;
@@ -465,6 +467,15 @@ lively.morphic.Morph.subclass('lively.morphic.CodeEditor',
     showsCompleter: function() {
         return this.withAceDo(function(ed) {
             return ed.completer && ed.completer.activated; })
+    },
+
+    activateAutocompletionWhenTyping: function() {
+        var editor = this.aceEditor;
+        editor.commands.on("afterExec", function(e){
+             if (e.command.name == "insertstring"&&/^[\w.]$/.test(e.args)) {
+                editor.execCommand("startAutocomplete")
+             }
+        })
     }
 
 },

--- a/core/lively/ide/CodeEditor.js
+++ b/core/lively/ide/CodeEditor.js
@@ -190,10 +190,9 @@ lively.morphic.Morph.subclass('lively.morphic.CodeEditor',
         this.setTabSize(this.getTabSize());
         this.setShowActiveLine(this.getShowActiveLine());
         this.setAutocompletionEnabled(this.getAutocompletionEnabled());
+        this.initializeAutoTriggerAutocompletion();
         this.setShowWarnings(this.getShowWarnings());
         this.setInputAllowed(this.inputAllowed());
-
-        this.activateAutocompletionWhenTyping();
 
         // 4) run after setup callbacks
         var cbs = this.aceEditorAfterSetupCallbacks;
@@ -469,12 +468,16 @@ lively.morphic.Morph.subclass('lively.morphic.CodeEditor',
             return ed.completer && ed.completer.activated; })
     },
 
-    activateAutocompletionWhenTyping: function() {
+    initializeAutoTriggerAutocompletion: function() {
+        this.setAutoTriggerAutocompletionEnabled(Config.get('aceDefaultAutoTriggerAutocompletion'));
         var editor = this.aceEditor;
+        var _this = this;
         editor.commands.on("afterExec", function(e){
-             if (e.command.name == "insertstring"&&/^[\w.]$/.test(e.args)) {
-                editor.execCommand("startAutocomplete")
-             }
+            if (_this.getAutoTriggerAutocompletionEnabled()) {
+                if (e.command.name == "insertstring" && /^[\w.]$/.test(e.args)) {
+                    editor.execCommand("startAutocomplete")
+                }
+            }
         })
     }
 
@@ -1203,7 +1206,12 @@ lively.morphic.Morph.subclass('lively.morphic.CodeEditor',
         return this.hasOwnProperty("_AutocompletionEnabled") ? this._AutocompletionEnabled : this.withAceDo(function(ed) {
             return ed.getOption("enableBasicAutocompletion"); });
     },
-
+    setAutoTriggerAutocompletionEnabled: function(bool) {
+        this._AutoTriggerAutocompletionEnabled = bool;
+    },
+    getAutoTriggerAutocompletionEnabled: function() {
+        return this._AutoTriggerAutocompletionEnabled;
+    },
     setShowWarnings: function(bool) { return this._ShowWarnings = bool; },
     getShowWarnings: function() {
         return this.hasOwnProperty("_ShowWarnings") ? this._ShowWarnings : true
@@ -1341,6 +1349,7 @@ lively.morphic.Morph.subclass('lively.morphic.CodeEditor',
         boolItem({name: "ShowWarnings", menuString: "show warnings"}, settingsItems);
         boolItem({name: "ShowErrors", menuString: "show Errors"}, settingsItems);
         boolItem({name: "AutocompletionEnabled", menuString: "use Autocompletion"}, settingsItems);
+        boolItem({name: "AutoTriggerAutocompletionEnabled", menuString: "automatically trigger Autocompletion"}, settingsItems);
         items.push(['settings', settingsItems]);
 
         var mac = UserAgent.isMacOS;


### PR DESCRIPTION
I noticed, that the autocompletion of the ace editor only shows up, if you press ctrl+space. I changed it so that autocompletion is triggered when typing (like it is done in most editors).
Maybe you want to check if this behaviour feels right within the LivelyKernel.
