### PR TITLE
Allow overriding the commandLineServerURL

### DIFF
--- a/core/lively/ide/CommandLineInterface.js
+++ b/core/lively/ide/CommandLineInterface.js
@@ -17,7 +17,7 @@ Object.subclass('lively.ide.CommandLineInterface.Command',
         this._commandString = commandString;
         options = options || {};
         options.cwd = options.cwd || lively.ide.CommandLineInterface.rootDirectory;
-        options.commandLineServerURL = options.commandLineServerURL = lively.ide.CommandLineInterface.commandLineServerURL;
+        options.commandLineServerURL = options.commandLineServerURL || lively.ide.CommandLineInterface.commandLineServerURL;
         options.ansiAttributesRegexp = options.hasOwnProperty("ansiAttributeEscape") ? options.ansiAttributeEscape : lively.ide.CommandLineInterface.ansiAttributesRegexp;
         this._options = options;
     }


### PR DESCRIPTION
In the Command class, the optional commandLineServerURL was just overridden. I guess this was accidental, anyway, I'd like to be able to do that.
