### PR TITLE
PR: Change code editor shortcuts for windows to avoid conflicts with standard OS behaviour

### DIFF
--- a/core/lib/ace/lively-ace.js
+++ b/core/lib/ace/lively-ace.js
@@ -11940,7 +11940,7 @@ exports.commands = [{
     readOnly: true
 }, {
     name: "foldall",
-    bindKey: bindKey("Ctrl-Alt-0", "Ctrl-Command-Option-0"),
+    bindKey: bindKey("Ctrl-Alt-Shift-0", "Ctrl-Command-Option-0"),
     exec: function(editor) { editor.session.foldAll(); },
     scrollIntoView: "center",
     readOnly: true

--- a/core/lively/ide/codeeditor/Keyboard.js
+++ b/core/lively/ide/codeeditor/Keyboard.js
@@ -317,25 +317,25 @@ Object.subclass('lively.ide.CodeEditor.KeyboardShortcuts',
                 readOnly: true
             }, {
                 name: 'moveForwardToMatching',
-                bindKey: {win: 'Ctrl-Right',  mac: 'Command-Right'},
+                bindKey: {win: 'Ctrl-M',  mac: 'Command-Right'},
                 exec: this.morphBinding("moveForwardToMatching", [false, true]),
                 multiSelectAction: "forEach",
                 readOnly: true
             }, {
                 name: 'moveBackwardToMatching',
-                bindKey: {win: 'Ctrl-Left',  mac: 'Command-Left'},
+                bindKey: {win: 'Ctrl-Alt-M',  mac: 'Command-Left'},
                 exec: this.morphBinding("moveBackwardToMatching", [false, true]),
                 multiSelectAction: "forEach",
                 readOnly: true
             }, {
                 name: 'selectToMatchingForward',
-                bindKey: {win: 'Ctrl-Shift-Right',  mac: 'Command-Shift-Right'},
+                bindKey: {win: 'Ctrl-Shift-M',  mac: 'Command-Shift-Right'},
                 exec: this.morphBinding("moveForwardToMatching", [true, true]),
                 multiSelectAction: "forEach",
                 readOnly: true
             }, {
                 name: 'selectToMatchingBackward',
-                bindKey: {win: 'Ctrl-Shift-Left',  mac: 'Command-Shift-Left'},
+                bindKey: {win: 'Ctrl-Shift-Alt-M',  mac: 'Command-Shift-Left'},
                 exec: this.morphBinding("moveBackwardToMatching", [true, true]),
                 multiSelectAction: "forEach",
                 readOnly: true


### PR DESCRIPTION
This would fix #196.
