### PR TITLE
Fixing XMLSerializer (not) encoding ampersands in world data

### DIFF
--- a/core/lively/Main.js
+++ b/core/lively/Main.js
@@ -61,7 +61,15 @@ Object.extend(lively.Main.WorldDataAccessor, {
 
     forHTMLDoc: function(doc) {
         // get the first script tag with the x-lively-world type
-        var json = lively.$(doc).find('script[type="text/x-lively-world"]').text();
+        var worldTag = lively.$(doc).find('script[type="text/x-lively-world"]'),
+            json;
+        // FIXME: LivelyMigrationSupport.documentMigrationLevel should not return 0
+        if (worldTag.attr('data-migrationlevel') < 9)
+            json =  worldTag.text();
+        else {
+            var xmlDoc = lively.$.parseXML(worldTag[0].outerHTML);
+            json = xmlDoc.children[0].textContent
+        }
         return new lively.Main.JSONMorphicData(doc, json);
     }
 });

--- a/core/lively/bootstrap.js
+++ b/core/lively/bootstrap.js
@@ -1181,7 +1181,7 @@
     var LivelyMigrationSupport = Global.LivelyMigrationSupport = {
         // increase this value by hand if you make a change that effects
         // object layout LivelyMigrationSupport.migrationLevel
-        migrationLevel: 8,
+        migrationLevel: 9,
         documentMigrationLevel: 0,
         migrationLevelNodeId: 'LivelyMigrationLevel',
         moduleRenameDict: {},

--- a/core/lively/persistence/Serializer.js
+++ b/core/lively/persistence/Serializer.js
@@ -1365,9 +1365,11 @@ Object.subclass('lively.persistence.HTMLDocBuilder',
         var el = this.createScriptEl({
             id: id,
             parent: this.body[0],
-            textContent: json,
             type: 'text/x-lively-world'
         });
+        var xml = lively.$.parseXML('<xml />'),
+            cdata = xml.createCDATASection(json);
+        el.appendChild(cdata);
         lively.$(el).attr('data-migrationLevel', migrationLevel);
     },
 


### PR DESCRIPTION
There is a bug using XMLSerializer on different OSs and in different browsers. The Firefox for example consequently encodes the serialized world data inside the script tag (WIN and Mac). Chrome does the same when in Windows (@timfel).

Easiest way to reproduce, is to open a blank world, add a morph and a script containing an ampersand (`true && false`). If the script tag gets encoded, the world cannot be deserialized anymore.

This fix increases the LivelyMigrationLevel and fixes serialization and deserialization accordingly by wrapping the world data script tag with an CDATA element. 
