### PR TITLE
fix bug in Array.min

### DIFF
--- a/core/lively/lang/Array.js
+++ b/core/lively/lang/Array.js
@@ -175,7 +175,7 @@ Object.extend(Array.prototype, {
         var value, result, resultValue;
         this.forEach(function(element, index) {
             value = iterator(element, index);
-            if (!result || value < resultValue) {
+            if (result === undefined || value < resultValue) {
                 result = element;
                 resultValue = value;
             }


### PR DESCRIPTION
`[0, 1].min()` yields 1, because the min-function checks if the current minimum value is initialized by using `!result`. I changed it to compare explicitly with `undefined`.
