### PR TITLE
Fix for Firefox

### DIFF
--- a/core/lively/Base.js
+++ b/core/lively/Base.js
@@ -30,7 +30,7 @@
   * LK class system.
   */
 
-if (!Function.prototype.name) {
+if (Function.prototype.name === undefined) {
     Function.prototype.__defineGetter__("name", function () {
 	var md = (this + "").match(/function\s+(.*)\s*\(\s*/);
 	if (md) {


### PR DESCRIPTION
On Firefox, `Function.prototype.name` returns `""`, which is false-y. Check for undefined.
