### PR TITLE
Prevent cyclic feedback on TextMorph grow/shrink

### DIFF
--- a/core/lively/morphic/TextCore.js
+++ b/core/lively/morphic/TextCore.js
@@ -493,7 +493,7 @@ lively.morphic.Morph.subclass('lively.morphic.Text', Trait('TextChunkOwner'),
   
     growOrShrinkToFit: function() {
         var padding = this.getPadding(),
-            fullExtent = this.getTextExtent().addXY(
+            fullExtent = (this.getTextString() == "" ? lively.pt(0,0) : this.getTextExtent()).addXY(
               padding.left() + padding.right(),
               padding.top() + padding.bottom());
         if (!this.getExtent().eqPt(fullExtent))


### PR DESCRIPTION
This change is one way to work around issue #335 "empty TextMorph grows uncontrollably under some conditions".  Under some circumstances, an empty TextMorph will return its getExtent() size when asked for getTextExtent(); when that happens, clearly we shouldn't be adding the padding size again.

This particular fix could change the resizing behaviour of editable text morphs in certain kinds of layout: if the user deletes the last character, the morph could collapse to its padding size (though I haven't yet managed to induce that behaviour; typically, the morph at least stays tall enough to include a cursor).
