### PR TITLE
Load lively.notifications on boot

### DIFF
--- a/core/lively/config.json
+++ b/core/lively/config.json
@@ -16,6 +16,7 @@
     ["bootstrapFiles", [
 	    "node_modules/lively.lang/dist/lively.lang.dev.js",
 	    "node_modules/lively.ast/dist/lively.ast_no-deps.js",
+	    "node_modules/lively.notifications/dist/lively.notifications_no-deps.js",
 	    "node_modules/lively.vm/dist/lively.vm_no-deps.js",
 	    "node_modules/lively.modules/dist/lively.modules_no-deps.js",
       "core/lively/Migration.js",

--- a/core/servers/OptimizedLoadingServer.js
+++ b/core/servers/OptimizedLoadingServer.js
@@ -71,6 +71,7 @@ function prepareFileForConcat(rootDir, cacheDir, file) {
           .concat([
       	    "node_modules/lively.lang/dist/lively.lang.dev.js",
       	    "node_modules/lively.ast/dist/lively.ast_no-deps.js",
+      	    "node_modules/lively.notifications/dist/lively.notifications_no-deps.js",
       	    "node_modules/lively.modules/dist/lively.modules_no-deps.js",
       	    "node_modules/lively.vm/dist/lively.vm_no-deps.js"]),
         cacheFile = path.join(cacheDir, file.replace(/\//g, "_")),

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lively.modules": "*",
     "lively.morphic": "*",
     "lively.sync": "*",
+    "lively.notifications": "*",
     "lively.resources": "*",
     "lively.serializer": "*",
     "lively.serializer2": "*",


### PR DESCRIPTION
This is a required dependency for lively.modules and lively.vm and needs to be loaded on startup.